### PR TITLE
Postgres-OLAP: Refactor to use parameter values provided by AWS

### DIFF
--- a/modules/autotune-postgresql/shared.tf
+++ b/modules/autotune-postgresql/shared.tf
@@ -2,8 +2,8 @@
 data "aws_db_parameter_group" "shared_settings" {
   logging = [
     {
-      name = ""
-      value = ""
+      name         = ""
+      value        = ""
       apply_method = ""
     },
     {

--- a/modules/autotune-postgresql/variables.tf
+++ b/modules/autotune-postgresql/variables.tf
@@ -1,0 +1,9 @@
+
+variable "workload_type" {
+  type = string
+  description = "Database workload type. Must be one of (`olap`, `oltp`, `hybrid`)"
+  validation {
+    condition     = contains(["oltp", "olap", "hybrid"], var.workload_type)
+    error_message = "Valid values for `var.workload_type` are (oltp, olap, hybrid)"
+  }
+}


### PR DESCRIPTION
**Changes:**
* Favor AWS built-in variables like `DBInstanceClassMemory` over mapped values
* Notes on the "gotchas" for the math