### PR TITLE
RDS: Logging for cloudwatch + KMS

### DIFF
--- a/modules/autotune-rds/rds.tf
+++ b/modules/autotune-rds/rds.tf
@@ -91,6 +91,32 @@ resource "aws_db_instance" "autotune-rds" {
 }
 
 #######################
+# CloudWatch logging
+#######################
+resource "aws_kms_key" "autotune-cloudwatch-kms" {
+  count = var.create_cloudwatch_log_group ? 1 : 0
+
+  description = "KMS Key for ${aws_db_instance.autotune-rds.identifier} CloudWatch logging"
+  deletion_window_in_days = 7
+  is_enabled = true
+  tags                                  = merge(var.tags, local.autotune_tags)
+}
+
+resource "aws_kms_alias" "autotune-cloudwatch-kms-alias" {
+  name = "alias/${aws_db_instance.autotune-rds.identifier}-cloudwatch-key-alias"
+  target_key_id = aws_kms_key.autotune-cloudwatch-kms.key_id
+}
+
+resource "aws_cloudwatch_log_group" "autotune-cloudwatch-logs" {
+  for_each = toset([for log in var.enabled_cloudwatch_logs_exports : log if var.create_cloudwatch_log_group])
+
+  name = "/rds/${aws_db_instance.autotune-rds.engine}/"
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id = aws_kms_key.autotune-cloudwatch-kms.key_id
+  tags                                  = merge(var.tags, local.autotune_tags)
+}
+
+#######################
 # SSM Parameters
 #######################
 locals {
@@ -115,6 +141,5 @@ resource "aws_ssm_parameter" "autotune-rds-password" {
   tags        = merge(var.tags, local.autotune_tags)
   type        = "SecureString"
   value       = local.db_password
-
 }
 

--- a/modules/autotune-rds/variables.tf
+++ b/modules/autotune-rds/variables.tf
@@ -1,4 +1,19 @@
 ############################
+# CloudWatch log group
+############################
+variable "create_cloudwatch_log_group" {
+  type = bool
+  description = "Controls whether or not to create CloudWatch log groups for each type of `var.enabled_cloudwatch_logs_exports`"
+  default = true
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  type = number
+  description = "Retention for logs in days"
+  default = 14
+}
+
+############################
 # User parameters in SSM
 ############################
 variable "db_ssm_credentials" {
@@ -121,6 +136,12 @@ variable "domain_iam_role_name" {
   type        = string
   description = "The name of the IAM role to be used when making API calls to the Directory Service. Required if `domain` is provided"
   default     = null
+}
+
+variable "enabled_cloudwatch_logs_exports" {
+  type = list(string)
+  description = "Enable or disable exports of RDS logs to CloudWatch"
+  default = []
 }
 
 variable "engine" {


### PR DESCRIPTION
**Changes:**
* Adds CloudWatch logging with default retention of 7 days for each log type in `var.enabled_cloudwatch_logs_exports`
* Adds KMS key and KMS key alias for CloudWatch log groups